### PR TITLE
Add Flask demo endpoints with tests

### DIFF
--- a/firstApp.py
+++ b/firstApp.py
@@ -1,6 +1,6 @@
 # export FLASK_APP=firstApp.py
 # flask run
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_celery import make_celery
 import redis
 
@@ -23,9 +23,36 @@ examples = [{'name': "Example 0",
 
 @app.route('/')
 def index():
-    	text = "Welcome Yipi's API REST"
-    	celery_monitor.delay("User in main page")
-    	return text
+        text = "Welcome Yipi's API REST"
+        celery_monitor.delay("User in main page")
+        return text
+
+# Simple health check route
+@app.route('/ping')
+def ping():
+        return jsonify({'message': 'pong'})
+
+# Echo a query parameter
+@app.route('/echo')
+def echo():
+        msg = request.args.get('msg', '')
+        return jsonify({'echo': msg})
+
+# Multiply two numbers from the URL
+@app.route('/multiply/<int:a>/<int:b>')
+def multiply(a, b):
+        return jsonify({'result': a * b})
+
+# Receive JSON payload and return it back
+@app.route('/json', methods=['POST'])
+def json_endpoint():
+        data = request.get_json(silent=True) or {}
+        return jsonify({'you_sent': data})
+
+# Receive form data and echo it
+@app.route('/form', methods=['POST'])
+def form_endpoint():
+        return jsonify({'form_data': request.form.to_dict()})
 
 # For run introduce the next url:
 # http://127.0.0.1:5000/examples

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,30 @@
+import pytest
+from firstApp import app
+
+@pytest.fixture
+
+def client():
+    with app.test_client() as client:
+        yield client
+
+def test_ping(client):
+    res = client.get('/ping')
+    assert res.status_code == 200
+    assert res.get_json() == {'message': 'pong'}
+
+def test_echo(client):
+    res = client.get('/echo?msg=hello')
+    assert res.status_code == 200
+    assert res.get_json() == {'echo': 'hello'}
+
+def test_multiply(client):
+    res = client.get('/multiply/2/3')
+    assert res.get_json() == {'result': 6}
+
+def test_json_endpoint(client):
+    res = client.post('/json', json={'foo': 'bar'})
+    assert res.get_json() == {'you_sent': {'foo': 'bar'}}
+
+def test_form_endpoint(client):
+    res = client.post('/form', data={'name': 'Alice'})
+    assert res.get_json() == {'form_data': {'name': 'Alice'}}


### PR DESCRIPTION
## Summary
- add new Flask routes for ping, echo, multiply, json, and form
- test the new endpoints using pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847fcd463ec8333a054ece17285bbfd